### PR TITLE
Feature gl01/sending json responses

### DIFF
--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (app *application) logError(r *http.Request, err error) {
+	app.logger.Print(err)
+}
+
+func (app *application) errorResponse(w http.ResponseWriter, r *http.Request, status int, message any) {
+	env := envelope{"error": message}
+
+	err := app.writeJSON(w, status, env, nil)
+	if err != nil {
+		app.logError(r, err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (app *application) serverErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	app.logError(r, err)
+
+	message := "the server encountered a problem and could not process your request"
+	app.errorResponse(w, r, http.StatusInternalServerError, message)
+}
+
+func (app *application) notFoundResponse(w http.ResponseWriter, r *http.Request) {
+	message := "the requested resource could not be found"
+	app.errorResponse(w, r, http.StatusNotFound, message)
+}
+
+func (app *application) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request) {
+	message := fmt.Sprintf("the %s method is not supported for this resource", r.Method)
+	app.errorResponse(w, r, http.StatusMethodNotAllowed, message)
+}

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -15,7 +15,6 @@ func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Reques
 
 	err := app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {
-		app.logger.Print(err)
-		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)
+		app.serverErrorResponse(w, r, err)
 	}
 }

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -5,12 +5,15 @@ import (
 )
 
 func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
-	data := map[string]string{
-		"status":      "available",
-		"environment": app.config.env,
-		"version":     version,
+	env := envelope{
+		"status": "available",
+		"system_info": map[string]string{
+			"environment": app.config.env,
+			"version":     version,
+		},
 	}
-	err := app.writeJSON(w, http.StatusOK, data, nil)
+
+	err := app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {
 		app.logger.Print(err)
 		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -1,15 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 )
 
 func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
-	js := `{"status": "available", "environment": %q, "version": %q}`
-	js = fmt.Sprintf(js, app.config.env, version)
-
-	w.Header().Set("Content-Type", "application/json")
-
-	fmt.Fprintln(w, js)
+	data := map[string]string{
+		"status":      "available",
+		"environment": app.config.env,
+		"version":     version,
+	}
+	err := app.writeJSON(w, data, http.StatusOK, nil)
+	if err != nil {
+		app.logger.Print(err)
+		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)
+	}
 }

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -10,7 +10,7 @@ func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Reques
 		"environment": app.config.env,
 		"version":     version,
 	}
-	err := app.writeJSON(w, data, http.StatusOK, nil)
+	err := app.writeJSON(w, http.StatusOK, data, nil)
 	if err != nil {
 		app.logger.Print(err)
 		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -5,8 +5,11 @@ import (
 	"net/http"
 )
 
-func (app *application) healthcheck(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "status: available")
-	fmt.Fprintf(w, "environment: %s\n", app.config.env)
-	fmt.Fprintf(w, "version: %s\n", version)
+func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	js := `{"status": "available", "environment": %q, "version": %q}`
+	js = fmt.Sprintf(js, app.config.env, version)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	fmt.Fprintln(w, js)
 }

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -20,7 +20,7 @@ func (app *application) readIDParam(r *http.Request) (int64, error) {
 	return id, nil
 }
 
-func (app *application) writeJSON(w http.ResponseWriter, data any, status int, headers http.Header) error {
+func (app *application) writeJSON(w http.ResponseWriter, status int, data any, headers http.Header) error {
 	js, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -17,4 +18,23 @@ func (app *application) readIDParam(r *http.Request) (int64, error) {
 	}
 
 	return id, nil
+}
+
+func (app *application) writeJSON(w http.ResponseWriter, data any, status int, headers http.Header) error {
+	js, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	js = append(js, '\n')
+
+	for key, value := range headers {
+		w.Header()[key] = value
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(js)
+
+	return nil
 }

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -20,8 +20,10 @@ func (app *application) readIDParam(r *http.Request) (int64, error) {
 	return id, nil
 }
 
+type envelope map[string]any
+
 func (app *application) writeJSON(w http.ResponseWriter, status int, data any, headers http.Header) error {
-	js, err := json.Marshal(data)
+	js, err := json.MarshalIndent(data, "", "\t")
 	if err != nil {
 		return err
 	}

--- a/cmd/api/movies.go
+++ b/cmd/api/movies.go
@@ -28,7 +28,7 @@ func (app *application) showMovieHandler(w http.ResponseWriter, r *http.Request)
 		Version:   1,
 	}
 
-	err = app.writeJSON(w, http.StatusOK, movie, nil)
+	err = app.writeJSON(w, http.StatusOK, envelope{"movies": movie}, nil)
 	if err != nil {
 		app.logger.Print(err)
 		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)

--- a/cmd/api/movies.go
+++ b/cmd/api/movies.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/alomia/greenlight/internal/data"
 )
 
 func (app *application) createMovieHandler(w http.ResponseWriter, r *http.Request) {
@@ -16,5 +19,18 @@ func (app *application) showMovieHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	fmt.Fprintf(w, "show the details of movie %d\n", id)
+	movie := data.Movie{
+		ID:        id,
+		CreatedAt: time.Now(),
+		Title:     "Pretty Woman",
+		Runtime:   119,
+		Genres:    []string{"Comedy", "Romance"},
+		Version:   1,
+	}
+
+	err = app.writeJSON(w, http.StatusOK, movie, nil)
+	if err != nil {
+		app.logger.Print(err)
+		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)
+	}
 }

--- a/cmd/api/movies.go
+++ b/cmd/api/movies.go
@@ -15,7 +15,7 @@ func (app *application) createMovieHandler(w http.ResponseWriter, r *http.Reques
 func (app *application) showMovieHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := app.readIDParam(r)
 	if err != nil {
-		http.NotFound(w, r)
+		app.notFoundResponse(w, r)
 		return
 	}
 
@@ -30,7 +30,6 @@ func (app *application) showMovieHandler(w http.ResponseWriter, r *http.Request)
 
 	err = app.writeJSON(w, http.StatusOK, envelope{"movies": movie}, nil)
 	if err != nil {
-		app.logger.Print(err)
-		http.Error(w, "The server encountered a problem and could not process your request", http.StatusInternalServerError)
+		app.serverErrorResponse(w, r, err)
 	}
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -9,6 +9,9 @@ import (
 func (app *application) routes() *httprouter.Router {
 	router := httprouter.New()
 
+	router.NotFound = http.HandlerFunc(app.notFoundResponse)
+	router.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
+
 	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheckHandler)
 	router.HandlerFunc(http.MethodPost, "/v1/movies", app.createMovieHandler)
 	router.HandlerFunc(http.MethodGet, "/v1/movies/:id", app.showMovieHandler)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -9,7 +9,7 @@ import (
 func (app *application) routes() *httprouter.Router {
 	router := httprouter.New()
 
-	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheck)
+	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheckHandler)
 	router.HandlerFunc(http.MethodPost, "/v1/movies", app.createMovieHandler)
 	router.HandlerFunc(http.MethodGet, "/v1/movies/:id", app.showMovieHandler)
 

--- a/internal/data/movies.go
+++ b/internal/data/movies.go
@@ -1,0 +1,13 @@
+package data
+
+import "time"
+
+type Movie struct {
+	ID        int64     `json:"id"`
+	CreatedAt time.Time `json:"-"`
+	Title     string    `json:"title"`
+	Year      int32     `json:"year,omitempty"`
+	Runtime   int32     `json:"runtime,omitempty,string"`
+	Genres    []string  `json:"genres,omitempty"`
+	Version   int32     `json:"version"`
+}

--- a/internal/data/movies.go
+++ b/internal/data/movies.go
@@ -7,7 +7,7 @@ type Movie struct {
 	CreatedAt time.Time `json:"-"`
 	Title     string    `json:"title"`
 	Year      int32     `json:"year,omitempty"`
-	Runtime   int32     `json:"runtime,omitempty,string"`
+	Runtime   Runtime   `json:"runtime,omitempty"`
 	Genres    []string  `json:"genres,omitempty"`
 	Version   int32     `json:"version"`
 }

--- a/internal/data/runtime.go
+++ b/internal/data/runtime.go
@@ -1,0 +1,16 @@
+package data
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type Runtime int32
+
+func (r Runtime) MarshalJSON() ([]byte, error) {
+	jsonValue := fmt.Sprintf("%d mins", r)
+
+	quotedJSONValue := strconv.Quote(jsonValue)
+
+	return []byte(quotedJSONValue), nil
+}


### PR DESCRIPTION
# Sending JSON Responses

- Send JSON responses from your REST API (including error responses).
 
- Different techniques for customizing how Go objects are encoded in JSON - first using struct tags, and then leveraging the json.Marshaler interface.

- Create a reusable helper for sending JSON responses, which will ensure that all API responses have a sensible and consistent structure.